### PR TITLE
FormInput label not updated on change

### DIFF
--- a/src/website/FormBuilder/FormInput.tsx
+++ b/src/website/FormBuilder/FormInput.tsx
@@ -122,7 +122,7 @@ FormInput.schema = {
       label: 'Field Name',
     },
     {
-      name: 'lanel',
+      name: 'label',
       type: types.SideEditPropType.Text,
       label: 'Label',
     },


### PR DESCRIPTION
Fixed a typo that resulted in the label of the FormInput not correctly being applied when updated.